### PR TITLE
Fix Broken CI/CD Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+script:
+  - npm run verify


### PR DESCRIPTION
## Description

#1 added a `travis.yml` file which was suppose to enable the travis CI/CD tool which executes tests/linter during a PR.

However, the file was named incorrectly and instead needs to be `.travis.yml` (notice the leading period).

After this PR, hopefully that pipeline begins to work 🤞 